### PR TITLE
Potential fix for code scanning alert no. 1: Code injection

### DIFF
--- a/vulnerable.js
+++ b/vulnerable.js
@@ -12,12 +12,21 @@ app.use(bodyParser.json());
  * - Attackers can inject and execute arbitrary code.
  */
 app.post('/execute', (req, res) => {
-    let userInput = req.body.code;
-    try {
-        let result = vm.runInNewContext(userInput); // ⚠️ UNSAFE: Executes user-supplied JavaScript code
-        res.json({ result });
-    } catch (error) {
-        res.status(500).json({ error: 'Execution failed' });
+    const allowedCommands = {
+        'command1': () => { return 'Result of command1'; },
+        'command2': () => { return 'Result of command2'; },
+        // Add more allowed commands as needed
+    };
+    let userInput = req.body.command;
+    if (allowedCommands.hasOwnProperty(userInput)) {
+        try {
+            let result = allowedCommands[userInput]();
+            res.json({ result });
+        } catch (error) {
+            res.status(500).json({ error: 'Execution failed' });
+        }
+    } else {
+        res.status(400).json({ error: 'Invalid command' });
     }
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/nanzggits/secure-that3/security/code-scanning/1](https://github.com/nanzggits/secure-that3/security/code-scanning/1)

To fix this issue, we need to avoid executing user-supplied code directly. Instead, we should use a safer approach to handle the user input. One way to achieve this is by using a predefined set of allowed operations or commands that the user can request, and then safely executing those commands without using `vm.runInNewContext`.

Here is a detailed description of the fix:
1. Define a set of allowed operations or commands that the user can request.
2. Validate the user input against this set of allowed operations.
3. Execute the corresponding operation safely without using `vm.runInNewContext`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
